### PR TITLE
Create parent directories on install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ if [ -d "$DIR/latex/$PACKAGE_NAME" ]; then
 	copy_files $DIR/latex/$PACKAGE_NAME
 else
 	echo "Initial installation. Copying files:"
-	mkdir $DIR/latex/$PACKAGE_NAME
+	mkdir -p $DIR/latex/$PACKAGE_NAME
 	copy_files $DIR/latex/$PACKAGE_NAME
 fi
 


### PR DESCRIPTION
Adds a `-p` Option to `mkdir` in `install.sh`.

Background

For me, none of the proposed folders contained a `latex` folder.
Thus, creating a `$PACKAGE_NAME` directory there and consequently
`copy_files` failed.
