### PR TITLE
Changed \LoadClass{beamer} to \LoadClassWithOptions{beamer}

### DIFF
--- a/uulm-slides.cls
+++ b/uulm-slides.cls
@@ -1,6 +1,6 @@
 \ProvidesClass{uulm-slides}[2016/05/31 UUlm Slides]
 
-\LoadClass{beamer}
+\LoadClassWithOptions{beamer}
 
 \RequirePackage[english,ngerman,german]{babel}
 \RequirePackage{calc}


### PR DESCRIPTION
This allows compiling the slides with the "handout" option more easily.

The change makes it possible to enable handout mode by changing the line `\documentclass{uulm-slides}` to `\documentclass[handout]{uulm-slides}`. 

I didn't see an easy way of changing to handout mode before. The only obvious option was to edit the .cls file every time handout mode is required.